### PR TITLE
Optimize Hoppers

### DIFF
--- a/Spigot-API-Patches/0086-Optimize-Hoppers.patch
+++ b/Spigot-API-Patches/0086-Optimize-Hoppers.patch
@@ -1,0 +1,42 @@
+From 44fab81ef5ec64ef6a4676180201348e522edcd6 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Thu, 18 Jan 2018 01:00:27 -0500
+Subject: [PATCH] Optimize Hoppers
+
+Adds data about what Item related methods were used in InventoryMoveItem event
+so that the server can improve the performance of this event.
+
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+index 06ec99ae..b44cc45b 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryMoveItemEvent.java
+@@ -30,6 +30,8 @@ public class InventoryMoveItemEvent extends Event implements Cancellable {
+     private final Inventory destinationInventory;
+     private ItemStack itemStack;
+     private final boolean didSourceInitiate;
++    public boolean calledGetItem; // Paper
++    public boolean calledSetItem; // Paper
+ 
+     public InventoryMoveItemEvent(final Inventory sourceInventory, final ItemStack itemStack, final Inventory destinationInventory, final boolean didSourceInitiate) {
+         Validate.notNull(itemStack, "ItemStack cannot be null");
+@@ -55,7 +57,8 @@ public class InventoryMoveItemEvent extends Event implements Cancellable {
+      * @return ItemStack
+      */
+     public ItemStack getItem() {
+-        return itemStack.clone();
++        calledGetItem = true; // Paper - record this method was used for auto detection of mode
++        return itemStack; // Paper - Removed clone, handled better in Server
+     }
+ 
+     /**
+@@ -67,6 +70,7 @@ public class InventoryMoveItemEvent extends Event implements Cancellable {
+      */
+     public void setItem(ItemStack itemStack) {
+         Validate.notNull(itemStack, "ItemStack cannot be null.  Cancel the event if you want nothing to be transferred.");
++        calledSetItem = true; // Paper - record this method was used for auto detection of mode
+         this.itemStack = itemStack.clone();
+     }
+ 
+-- 
+2.15.1
+

--- a/Spigot-Server-Patches/0269-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0269-Optimize-Hoppers.patch
@@ -1,0 +1,249 @@
+From f912d9e9b985374f41e04ca3434945a4c567b20f Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Thu, 18 Jan 2018 00:54:23 -0500
+Subject: [PATCH] Optimize Hoppers
+
+- Lots of itemstack cloning removed. Only clone if the item is actually moved
+- Return true when a plugin cancels inventory move item event instead of false, as false causes pulls to cycle through all items.
+  However, pushes do not exhibit the same behavior, so this is not something plugins could of been relying on.
+- Add option (Default on) to cooldown hoppers when they fail to move an item due to full inventory
+- Skip subsequent InventoryMoveItemEvents if a plugin does not use the item after first event fire for an iteration
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 11e88663e..929c02d69 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -476,4 +476,12 @@ public class PaperWorldConfig {
+         squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
+     }
+ 
++    public boolean cooldownHopperWhenFull = true;
++    public boolean disableHopperMoveEvents = false;
++    private void hopperOptimizations() {
++        cooldownHopperWhenFull = getBoolean("hopper.cooldown-when-full", cooldownHopperWhenFull);
++        log("Cooldown Hoppers when Full: " + (cooldownHopperWhenFull ? "enabled" : "disabled"));
++        disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
++        log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 95d1ac442..e8c72db96 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -876,6 +876,7 @@ public abstract class MinecraftServer implements ICommandListener, Runnable, IAs
+ 
+             // if (i == 0 || this.getAllowNether()) {
+                 WorldServer worldserver = this.worlds.get(i);
++                TileEntityHopper.skipHopperEvents = worldserver.paperConfig.disableHopperMoveEvents || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0;
+ 
+                 this.methodProfiler.a(() -> {
+                     return worldserver.getWorldData().getName();
+diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
+index ebbe5d326..e5d0c6412 100644
+--- a/src/main/java/net/minecraft/server/TileEntityHopper.java
++++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
+@@ -196,6 +196,159 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         return false;
+     }
+ 
++    // Paper start - Optimize Hoppers
++    private static boolean skipPullModeEventFire = false;
++    private static boolean skipPushModeEventFire = false;
++    static boolean skipHopperEvents = false;
++
++    private boolean hopperPush(IInventory iinventory, EnumDirection enumdirection) {
++        skipPushModeEventFire = skipHopperEvents;
++        boolean foundItem = false;
++        for (int i = 0; i < this.getSize(); ++i) {
++            if (!this.getItem(i).isEmpty()) {
++                foundItem = true;
++                ItemStack origItemStack = this.getItem(i);
++                ItemStack itemstack = origItemStack;
++
++                final int origCount = origItemStack.getCount();
++                final int moved = Math.min(world.spigotConfig.hopperAmount, origCount);
++                origItemStack.setCount(moved);
++
++                // We only need to fire the event once to give protection plugins a chance to cancel this event
++                // Because nothing uses getItem, every event call should end up the same result.
++                if (!skipPushModeEventFire) {
++                    itemstack = callPushMoveEvent(iinventory, itemstack);
++                    if (itemstack == null) { // cancelled
++                        origItemStack.setCount(origCount);
++                        return false;
++                    }
++                }
++                final ItemStack itemstack1 = addItem(this, iinventory, itemstack, enumdirection);
++
++                if (itemstack1.isEmpty()) {
++                    origItemStack = origItemStack.cloneItemStack();
++                    origItemStack.setCount(origCount - moved);
++                    this.setItem(i, origItemStack);
++                    iinventory.update();
++                    return true;
++                }
++                origItemStack.setCount(origCount);
++            }
++        }
++        if (foundItem && world.paperConfig.cooldownHopperWhenFull) { // Inventory was full - cooldown
++            this.setCooldown(world.spigotConfig.hopperTransfer);
++        }
++        return false;
++    }
++
++    private static boolean hopperPull(IHopper ihopper, IInventory iinventory, int i) {
++        ItemStack origItemStack = iinventory.getItem(i);
++        ItemStack itemstack = origItemStack;
++        final int origCount = origItemStack.getCount();
++        final World world = ihopper.getWorld();
++        final int moved = Math.min(world.spigotConfig.hopperAmount, origCount);
++        itemstack.setCount(moved);
++
++        if (!skipPullModeEventFire) {
++            itemstack = callPullMoveEvent(ihopper, iinventory, itemstack);
++            if (itemstack == null) { // cancelled
++                origItemStack.setCount(origCount);
++                // Drastically improve performance by returning true.
++                // No plugin could of relied on the behavior of false as the other call
++                // site for IMIE did not exhibit the same behavior
++                return true;
++            }
++        }
++
++        final ItemStack itemstack2 = addItem(iinventory, ihopper, itemstack, null);
++        if (itemstack2.isEmpty()) {
++            origItemStack = origItemStack.cloneItemStack();
++            origItemStack.setCount(origCount - moved);
++            IGNORE_TILE_UPDATES = true;
++            iinventory.setItem(i, origItemStack);
++            IGNORE_TILE_UPDATES = false;
++            iinventory.update();
++            return true;
++        }
++        origItemStack.setCount(origCount);
++
++        if (world.paperConfig.cooldownHopperWhenFull) {
++            cooldownHopper(ihopper);
++        }
++
++        return false;
++    }
++
++    private ItemStack callPushMoveEvent(IInventory iinventory, ItemStack itemstack) {
++        Inventory destinationInventory = getInventory(iinventory);
++        InventoryMoveItemEvent event = new InventoryMoveItemEvent(this.getOwner(false).getInventory(),
++                CraftItemStack.asCraftMirror(itemstack), destinationInventory, true);
++        boolean result = event.callEvent();
++        if (!event.calledGetItem && !event.calledSetItem) {
++            skipPushModeEventFire = true;
++        }
++        if (!result) {
++            cooldownHopper(this);
++            return null;
++        }
++
++        if (event.calledSetItem) {
++            return CraftItemStack.asNMSCopy(event.getItem());
++        } else {
++            return itemstack;
++        }
++    }
++
++    private static ItemStack callPullMoveEvent(IHopper hopper, IInventory iinventory, ItemStack itemstack) {
++        Inventory sourceInventory = getInventory(iinventory);
++
++        Inventory destination;
++        if (hopper instanceof TileEntity) {
++            destination = ((TileEntity) hopper).getOwner(false).getInventory();
++        } else {
++            destination = hopper.getOwner().getInventory();
++        }
++
++        InventoryMoveItemEvent event = new InventoryMoveItemEvent(sourceInventory,
++                // Mirror is safe as we no plugins ever use this item
++                CraftItemStack.asCraftMirror(itemstack), destination, false);
++        boolean result = event.callEvent();
++        if (!event.calledGetItem && !event.calledSetItem) {
++            skipPullModeEventFire = true;
++        }
++        if (!result) {
++            cooldownHopper(hopper);
++            return null;
++        }
++
++        if (event.calledSetItem) {
++            return CraftItemStack.asNMSCopy(event.getItem());
++        } else {
++            return itemstack;
++        }
++    }
++
++    private static Inventory getInventory(IInventory iinventory) {
++        Inventory sourceInventory;// Have to special case large chests as they work oddly
++        if (iinventory instanceof InventoryLargeChest) {
++            sourceInventory = new org.bukkit.craftbukkit.inventory.CraftInventoryDoubleChest((InventoryLargeChest) iinventory);
++        } else if (iinventory instanceof TileEntity) {
++            sourceInventory = ((TileEntity) iinventory).getOwner(false).getInventory();
++        } else {
++            sourceInventory = iinventory.getOwner().getInventory();
++        }
++        return sourceInventory;
++    }
++
++    private static void cooldownHopper(IHopper hopper) {
++        if (hopper instanceof TileEntityHopper) {
++            ((TileEntityHopper) hopper).setCooldown(hopper.getWorld().spigotConfig.hopperTransfer);
++        } else if (hopper instanceof EntityMinecartHopper) {
++            ((EntityMinecartHopper) hopper).setCooldown(hopper.getWorld().spigotConfig.hopperTransfer / 2);
++        }
++    }
++
++    // Paper end
+     private boolean s() {
+         IInventory iinventory = this.I();
+ 
+@@ -207,6 +360,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+             if (this.a(iinventory, enumdirection)) {
+                 return false;
+             } else {
++                return hopperPush(iinventory, enumdirection); /* // Paper - disable rest
+                 for (int i = 0; i < this.getSize(); ++i) {
+                     if (!this.getItem(i).isEmpty()) {
+                         ItemStack itemstack = this.getItem(i).cloneItemStack();
+@@ -254,7 +408,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+                     }
+                 }
+ 
+-                return false;
++                return false;*/ // Paper
+             }
+         }
+     }
+@@ -332,6 +486,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+             if (b(iinventory, enumdirection)) {
+                 return false;
+             }
++            skipPullModeEventFire = skipHopperEvents; // Paper
+ 
+             if (iinventory instanceof IWorldInventory) {
+                 IWorldInventory iworldinventory = (IWorldInventory) iinventory;
+@@ -374,6 +529,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         ItemStack itemstack = iinventory.getItem(i);
+ 
+         if (!itemstack.isEmpty() && b(iinventory, itemstack, i, enumdirection)) {
++            return hopperPull(ihopper, iinventory, i); /* // Paper - disable rest
+             ItemStack itemstack1 = itemstack.cloneItemStack();
+             // ItemStack itemstack2 = addItem(iinventory, ihopper, iinventory.splitStack(i, 1), (EnumDirection) null);
+             // CraftBukkit start - Call event on collection of items from inventories into the hopper
+@@ -426,7 +582,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+             }
+ 
+             itemstack1.subtract(origCount - itemstack2.getCount()); // Spigot
+-            iinventory.setItem(i, itemstack1);
++            iinventory.setItem(i, itemstack1);*/ // Paper
+         }
+ 
+         return false;
+-- 
+2.15.1
+


### PR DESCRIPTION
- Lots of itemstack cloning removed. Only clone if the item is actually moved
- Return true when a plugin cancels inventory move item event instead of false, as false causes pulls to cycle through all items.
  However, pushes do not exhibit the same behavior, so this is not something plugins could of been relying on.
- Add option (Default on) to cooldown hoppers when they fail to move an item due to full inventory
- Skip subsequent InventoryMoveItemEvents if a plugin does not use the item after first event fire for an iteration